### PR TITLE
feat(ui): Add quality selection UI for audio-only content

### DIFF
--- a/ui/locales/en-GB.json
+++ b/ui/locales/en-GB.json
@@ -26,6 +26,7 @@
   "PICTURE_IN_PICTURE": "Picture-in-picture",
   "PLAY": "Play",
   "PLAYBACK_RATE": "Playback speed",
+  "QUALITY": "Quality",
   "RESOLUTION": "Resolution",
   "REWIND": "Rewind",
   "SEEK": "Seek",

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -27,6 +27,7 @@
   "PICTURE_IN_PICTURE": "Picture-in-Picture",
   "PLAY": "Play",
   "PLAYBACK_RATE": "Playback speed",
+  "QUALITY": "Quality",
   "RESOLUTION": "Resolution",
   "REWIND": "Rewind",
   "SEEK": "Seek",

--- a/ui/locales/source.json
+++ b/ui/locales/source.json
@@ -113,6 +113,11 @@
     "message": "Playback speed",
     "description": "Label for a button used to navigate to a submenu to choose the playback speed in the video player."
   },
+  "QUALITY": {
+    "description": "Label for a button used to open a submenu to choose a audio quality in the video player.",
+    "meaning": "Audio quality",
+    "message": "Quality"
+  },
   "RESOLUTION": {
     "description": "Label for a button used to open a submenu to choose a video resolution in the video player.",
     "meaning": "Visual quality",

--- a/ui/resolution_selection.js
+++ b/ui/resolution_selection.js
@@ -209,25 +209,18 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
     const LocIds = shaka.ui.Locales.Ids;
 
     // Assign text attributes depending on content type.
-    if (this.player.isAudioOnly()) {
-      this.button.setAttribute(shaka.ui.Constants.ARIA_LABEL,
-          this.localization.resolve(LocIds.QUALITY));
-      this.backButton.setAttribute(shaka.ui.Constants.ARIA_LABEL,
-          this.localization.resolve(LocIds.QUALITY));
-      this.backSpan.textContent =
-          this.localization.resolve(LocIds.QUALITY);
-      this.nameSpan.textContent =
-          this.localization.resolve(LocIds.QUALITY);
-    } else {
-      this.button.setAttribute(shaka.ui.Constants.ARIA_LABEL,
-          this.localization.resolve(LocIds.RESOLUTION));
-      this.backButton.setAttribute(shaka.ui.Constants.ARIA_LABEL,
-          this.localization.resolve(LocIds.RESOLUTION));
-      this.backSpan.textContent =
-        this.localization.resolve(LocIds.RESOLUTION);
-      this.nameSpan.textContent =
-        this.localization.resolve(LocIds.RESOLUTION);
-    }
+    const locId =
+        this.player.isAudioOnly() ? LocIds.QUALITY : LocIds.RESOLUTION;
+
+    this.button.setAttribute(shaka.ui.Constants.ARIA_LABEL,
+        this.localization.resolve(locId));
+    this.backButton.setAttribute(shaka.ui.Constants.ARIA_LABEL,
+        this.localization.resolve(locId));
+    this.backSpan.textContent =
+      this.localization.resolve(locId);
+    this.nameSpan.textContent =
+      this.localization.resolve(locId);
+
     this.abrOnSpan_.textContent =
         this.localization.resolve(LocIds.AUTO_QUALITY);
 

--- a/ui/resolution_selection.js
+++ b/ui/resolution_selection.js
@@ -88,7 +88,7 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
       if (this.player.isAudioOnly()) {
         // Keep the first one with the same bandwidth.
         otherIdx = tracks.findIndex(
-            (t) => t.audioBandwidth == track.audioBandwidth);
+            (t) => t.bandwidth == track.bandwidth);
       } else {
         // Keep the first one with the same height.
         otherIdx = tracks.findIndex((t) => t.height == track.height);
@@ -99,10 +99,10 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
     // Sort the tracks in height or bandwith depending on content type.
     if (this.player.isAudioOnly()) {
       tracks.sort((t1, t2) => {
-        goog.asserts.assert(t1.audioBandwidth != null, 'Null audioBandwidth');
-        goog.asserts.assert(t2.audioBandwidth != null, 'Null audioBandwidth');
+        goog.asserts.assert(t1.bandwidth != null, 'Null bandwidth');
+        goog.asserts.assert(t2.bandwidth != null, 'Null bandwidth');
 
-        return t2.audioBandwidth - t1.audioBandwidth;
+        return t2.bandwidth - t1.bandwidth;
       });
     } else {
       tracks.sort((t1, t2) => {
@@ -137,7 +137,7 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
 
       // Asign textContent depending on content type.
       if (this.player.isAudioOnly()) {
-        span.textContent = track.audioBandwidth + ' bits/s';
+        span.textContent = track.bandwidth + ' bits/s';
       } else {
         span.textContent = track.height + 'p';
       }


### PR DESCRIPTION
## Context

This is a draft pull request that is currently under development.

## Description

I approached the issue by introducing the quality selection to the currently existing resolution button in the UI, conditionally, when audio-only content is being displayed.

```js
tracks = tracks.filter((track, idx) => {
  // If audio-only content is being displayed
  if (this.player.isAudioOnly()) {
    // Keep the first one with the same audioBandwidth.
    otherIdx = tracks.findIndex(
        (t) => t.audioBandwidth == track.audioBandwidth);
  // If video content is being displayed
  } else {
    // Keep the first one with the same height.
    otherIdx = tracks.findIndex(
        (t) => t.height == track.height);
  }
  return otherIdx == idx;
});
```

Currently, this replaces the resolution menu with a quality menu when audio-only content is displayed, as shown in the following image:

<img align="center" src="https://nbcl.github.io/images/bits.png" />

## Draft status

Currently, the following points must be decided before resolving the draft.

- [x] Make sure the obtaining of the audio quality attribute is correct.
- [ ] Decide if a new button must be created to only handle audio quality or having the resolution button shift functionality depending on content is the correct design.